### PR TITLE
(misc) Switch from task_wrapper to execution_wrapper on FreeBSD

### DIFF
--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -2,4 +2,4 @@
 mcollective_choria::package_dependencies:
   "rubygem-choria-mcorpc-support": "present"
 mcollective_choria::config:
-  tasks.wrapper_path: /usr/local/bin/task_wrapper
+  tasks.wrapper_path: /usr/local/bin/execution_wrapper


### PR DESCRIPTION
The pxp-agent not yet available as a FreeBSD package, but since the
latest version installs execution_wrapper prefer this to the legacy
task_wrapper by default.