### PR TITLE
(#26) Add gem dependency for Puppet 8 support

### DIFF
--- a/data/puppet_aio/8.yaml
+++ b/data/puppet_aio/8.yaml
@@ -1,0 +1,2 @@
+mcollective_choria::gem_dependencies:
+  "choria-mcorpc-support": "2.26.2"


### PR DESCRIPTION
This allows mco shell run to work correctly.

Closes: #26